### PR TITLE
remove col/row bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -58,6 +58,7 @@ function removeR() {
   }
   numRows = numRows-1;
   document.getElementById("grid").deleteRow(numRows);
+  if(numRows == 0){numCols = 0;}
 }
 //Remove a column
 function removeC() {
@@ -69,6 +70,9 @@ function removeC() {
   for(let i = 0; i< numRows; i++){
       let row = table.rows[i];
       row.deleteCell(numCols);
+    }
+    if(numCols == 0){
+      numRows = 0;
     }
 }
 //sets global var for selected color


### PR DESCRIPTION
fixing a bug where when a table is effectively deleted by removing the last row or column, the variable numRows and numCol are updated so upon creating a new table the new table starts off with numRow=0 and numCol=0 to avoid excessive cells or tables with dents in them